### PR TITLE
Fix Vercel monorepo deployment by deploying from repo root

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,9 +72,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deploy to Vercel
-        run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: packages/frontend
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel
+
+      - name: Pull Vercel configuration
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build for Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy prebuilt to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/packages/frontend/vercel.json
+++ b/packages/frontend/vercel.json
@@ -1,7 +1,0 @@
-{
-  "github": { "enabled": false },
-  "installCommand": "cd ../.. && npm ci",
-  "buildCommand": "cd ../.. && npm run build -w @vitals/shared && npm run build -w @vitals/frontend",
-  "outputDirectory": "dist",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "npm run build -w @vitals/shared && npm run build -w @vitals/frontend",
+  "outputDirectory": "packages/frontend/dist",
+  "installCommand": "npm ci",
+  "framework": null,
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Move vercel.json from packages/frontend/ to repo root so the entire monorepo is available during Vercel's build. The previous setup ran `vercel deploy` from the frontend subdirectory, causing `cd ../..` commands to fail because parent directories weren't uploaded.

Changes:
- Move vercel.json to repo root with correct outputDirectory path
- Update CI workflow to use `vercel build` + `deploy --prebuilt` pattern, avoiding redundant builds (CI already builds everything)
- Remove working-directory constraint from deploy-frontend job

Vercel project Root Directory must be set to blank (repo root) in the dashboard for this to work.

https://claude.ai/code/session_017u3z2sWNarnHJ955PMyCfF