### PR TITLE
fix: trim FRONTEND_URL to prevent ERR_INVALID_CHAR in CORS header

### DIFF
--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -39,7 +39,7 @@ export function loadEnv(): EnvConfig {
     n8nApiKey: process.env.N8N_API_KEY || '',
     dbDefaultUserId: process.env.DB_DEFAULT_USER_ID || '00000000-0000-0000-0000-000000000001',
     nodeEnv: process.env.NODE_ENV || 'development',
-    frontendUrl: process.env.FRONTEND_URL || '',
+    frontendUrl: (process.env.FRONTEND_URL || '').trim(),
     cronometerUsername: process.env.CRONOMETER_USERNAME || process.env.CRON_USERNAME || '',
     cronometerPassword: process.env.CRONOMETER_PASSWORD || process.env.CRON_PASSWORD || '',
     cronometerGwtHeader: process.env.CRONOMETER_GWT_HEADER || '',


### PR DESCRIPTION
## Summary
- Railway deployment was crashing with `Invalid character in header content ["access-control-allow-origin"]`
- Root cause: `FRONTEND_URL` value in Railway had a hidden trailing character (whitespace/newline from pasting)
- Fix: `.trim()` the value in `loadEnv()` as a defensive guard

## Test plan
- [ ] Merge → CI redeploys Railway backend
- [ ] Verify `/health` returns 200 and CORS headers are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)