### PR TITLE
feat: Cronometer rate-limit detection + CSRF trailing-slash fix

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,14 @@ Query Layer (parallel)
 - **n8n webhooks:** `X-API-Key` header (compared against `N8N_API_KEY` env var)
 - **Frontend:** CORS-based (no auth token — single-user app)
 - **AI API:** Anthropic API key (`ANTHROPIC_API_KEY` env var)
-- **Cronometer:** Cookie-based GWT session auth (username/password + CSRF)
+- **Cronometer:** Cookie-based GWT session auth (username/password + CSRF). Auth flow:
+  1. `GET /login/` (trailing slash required — `/login` returns empty body) → extract `anticsrf` CSRF token from HTML
+  2. `POST /login` with credentials + CSRF → 302 redirect on success, JSON `{"error":"..."}` on failure
+  3. `POST /cronometer/app` GWT RPC → `authenticate` call returns numeric `userId`
+  4. `POST /cronometer/app` GWT RPC → `generateAuthorizationToken` call returns export token
+  5. `GET /export?nonce=<token>&generate=dailySummary` → CSV download
+
+  Rate-limit detection: login endpoint returns `{"error":"Too Many Attempts..."}` JSON or HTML containing "too many attempts"/"try again later" — both are caught and thrown before any retry.
 - **Hevy:** REST API key in `api-key` header
 
 ## Deployment

--- a/docs/plans/2026-03-13-cronometer-safety.md
+++ b/docs/plans/2026-03-13-cronometer-safety.md
@@ -194,9 +194,16 @@ In `packages/backend/package.json`:
 
 ## Success Criteria
 
-- [ ] `looksLikeLoginFailure()` catches "too many attempts" and "try again later"
-- [ ] `parseLoginResponse()` extracts JSON error messages from login endpoint
-- [ ] `ensureLogin()` throws with specific error on rate-limit JSON response
-- [ ] All new and existing unit tests pass
-- [ ] Smoke test script runs successfully with real credentials
+- [x] `looksLikeLoginFailure()` catches "too many attempts" and "try again later"
+- [x] `parseLoginResponse()` extracts JSON error messages from login endpoint
+- [x] `ensureLogin()` throws with specific error on rate-limit JSON response
+- [x] All new and existing unit tests pass (156 passing)
+- [x] Smoke test script runs successfully with real credentials (2026-03-12: 2212 kcal)
 - [ ] Daily Collection workflow executes successfully in n8n after local validation
+
+## Implementation Notes
+
+### Trailing-slash CSRF fix (not in original plan)
+During smoke-test execution, `GET /login` returned an empty body (`content-length: 0`).
+Cronometer's site changed — the login page HTML (and CSRF token) is only served at `GET /login/` (trailing slash).
+Fixed `getCsrfToken()` to try both URLs, matching the legacy project's approach.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "seed": "tsx scripts/seed-dev.ts",
+    "test:cronometer": "tsx scripts/test-cronometer.ts",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/backend/scripts/test-cronometer.ts
+++ b/packages/backend/scripts/test-cronometer.ts
@@ -1,0 +1,41 @@
+import 'dotenv/config';
+import { CronometerGwtClient } from '../src/services/collectors/cronometer/client.js';
+
+async function main() {
+  const { CRONOMETER_USERNAME, CRONOMETER_PASSWORD, CRONOMETER_GWT_HEADER, CRONOMETER_GWT_PERMUTATION } =
+    process.env;
+
+  if (!CRONOMETER_USERNAME || !CRONOMETER_PASSWORD) {
+    console.error('Missing CRONOMETER_USERNAME or CRONOMETER_PASSWORD in .env');
+    process.exit(1);
+  }
+  if (!CRONOMETER_GWT_HEADER || !CRONOMETER_GWT_PERMUTATION) {
+    console.error('Missing CRONOMETER_GWT_HEADER or CRONOMETER_GWT_PERMUTATION in .env');
+    process.exit(1);
+  }
+
+  const client = new CronometerGwtClient(
+    CRONOMETER_USERNAME,
+    CRONOMETER_PASSWORD,
+    CRONOMETER_GWT_HEADER,
+    CRONOMETER_GWT_PERMUTATION,
+  );
+
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  console.log(`Testing Cronometer export for ${yesterday.toISOString().slice(0, 10)}...`);
+
+  try {
+    const csv = await client.exportDailyNutrition(yesterday, yesterday);
+    const lines = csv.split('\n').filter(Boolean);
+    console.log(`Success! Got ${lines.length} lines:`);
+    lines.slice(0, 5).forEach((line) => console.log(`  ${line}`));
+    if (lines.length > 5) console.log(`  ... and ${lines.length - 5} more`);
+  } catch (err) {
+    console.error('Cronometer test FAILED:', err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/backend/src/services/collectors/cronometer/__tests__/client.test.ts
+++ b/packages/backend/src/services/collectors/cronometer/__tests__/client.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CronometerGwtClient } from '../client.js';
+
+function makeResponse(
+  body: string,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(body, { status, headers });
+}
+
+function mockFetchSequence(responses: Response[]): void {
+  const queue = [...responses];
+  globalThis.fetch = vi.fn().mockImplementation(() => {
+    const res = queue.shift();
+    if (!res) throw new Error('Unexpected fetch call — queue exhausted');
+    return Promise.resolve(res);
+  });
+}
+
+const GWT_HEADER = 'FAKEGWTHEADER1234567890ABCDEF';
+const GWT_PERMUTATION = 'FAKEPERMUTATION1234567890ABCD';
+
+function makeClient() {
+  return new CronometerGwtClient('user@test.com', 'pass123', GWT_HEADER, GWT_PERMUTATION);
+}
+
+// Minimal responses for a successful 5-step auth + export flow:
+// 1. GET /login  → CSRF token in HTML
+// 2. POST /login → 302 redirect
+// 3. GET redirect location → 200 OK
+// 4. POST GWT app (authenticate) → OK[12345,...]
+// 5. POST GWT app (generateAuthorizationToken) → "export-token"
+// 6. GET /export → CSV content
+function makeHappyPathResponses(): Response[] {
+  const csrf = makeResponse(
+    '<input name="anticsrf" value="testcsrf123">',
+    200,
+    { 'set-cookie': 'session=abc; Path=/' },
+  );
+  const login302 = makeResponse('', 302, {
+    location: 'https://cronometer.com/dashboard',
+    'set-cookie': 'auth=xyz; Path=/',
+  });
+  const redirect200 = makeResponse('Welcome', 200, { 'set-cookie': 'sesnonce=nonce999; Path=/' });
+  const gwtAuth = makeResponse('//OK[12345,["com.cronometer..."]]', 200, {
+    'set-cookie': 'sesnonce=nonce999; Path=/',
+  });
+  const gwtToken = makeResponse('//OK["export-token-abc"]', 200);
+  const csv = makeResponse('Date,Energy\n2026-03-12,2000\n', 200);
+  return [csrf, login302, redirect200, gwtAuth, gwtToken, csv];
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('CronometerGwtClient', () => {
+  it('throws immediately when credentials are missing', async () => {
+    const client = new CronometerGwtClient('', '', GWT_HEADER, GWT_PERMUTATION);
+    await expect(client.exportDailyNutrition(new Date(), new Date())).rejects.toThrow(
+      'Missing Cronometer credentials',
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('happy path returns CSV', async () => {
+    mockFetchSequence(makeHappyPathResponses());
+    const client = makeClient();
+    const start = new Date('2026-03-12');
+    const end = new Date('2026-03-12');
+    const result = await client.exportDailyNutrition(start, end);
+    expect(result).toContain('Date,Energy');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(6);
+  });
+
+  it('throws with JSON error message from login endpoint', async () => {
+    const csrf = makeResponse('<input name="anticsrf" value="testcsrf123">', 200);
+    const loginJson = makeResponse(
+      JSON.stringify({ success: false, error: 'Too Many Attempts. Please try again in 15 minutes.' }),
+      200,
+      { 'content-type': 'application/json' },
+    );
+    mockFetchSequence([csrf, loginJson]);
+    const client = makeClient();
+    await expect(client.exportDailyNutrition(new Date(), new Date())).rejects.toThrow(
+      'Too Many Attempts',
+    );
+  });
+
+  it('falls back to /login/ when /login returns empty body for CSRF', async () => {
+    // First GET /login → 200 but empty body (no CSRF token)
+    const emptyLogin = makeResponse('', 200);
+    // Second GET /login/ → 200 with CSRF token
+    const loginWithCsrf = makeResponse(
+      '<input name="anticsrf" value="testcsrf123">',
+      200,
+      { 'set-cookie': 'session=abc; Path=/' },
+    );
+    const rest = makeHappyPathResponses().slice(1); // skip the first CSRF fetch
+    mockFetchSequence([emptyLogin, loginWithCsrf, ...rest]);
+    const client = makeClient();
+    const result = await client.exportDailyNutrition(new Date('2026-03-12'), new Date('2026-03-12'));
+    expect(result).toContain('Date,Energy');
+    // 7 fetches: 2 CSRF attempts + login POST + redirect follow + GWT auth + GWT token + export
+    expect(globalThis.fetch).toHaveBeenCalledTimes(7);
+  });
+
+  it('throws when login body contains rate-limit text', async () => {
+    const csrf = makeResponse('<input name="anticsrf" value="testcsrf123">', 200);
+    const loginHtml = makeResponse(
+      '<html>Error: too many attempts, try again later.</html>',
+      200,
+    );
+    mockFetchSequence([csrf, loginHtml]);
+    const client = makeClient();
+    await expect(client.exportDailyNutrition(new Date(), new Date())).rejects.toThrow(
+      'Cronometer login failed',
+    );
+  });
+});

--- a/packages/backend/src/services/collectors/cronometer/client.ts
+++ b/packages/backend/src/services/collectors/cronometer/client.ts
@@ -129,6 +129,14 @@ export class CronometerAuthSession {
       }
     } else if (response.status === 200) {
       const text = await response.text();
+      const loginResponse = parseLoginResponse(response.headers.get('content-type'), text);
+      if (loginResponse?.error) {
+        const msg = String(loginResponse.error).replace(/[\r\n]/g, ' ').slice(0, 200);
+        throw new Error(`Cronometer login failed: ${msg}`);
+      }
+      if (loginResponse && loginResponse.success === false) {
+        throw new Error('Cronometer login failed: unknown response');
+      }
       if (looksLikeLoginFailure(text)) {
         throw new Error('Cronometer login failed (invalid credentials or MFA required)');
       }
@@ -141,15 +149,26 @@ export class CronometerAuthSession {
   }
 
   private async getCsrfToken(): Promise<string> {
-    const headers = new Headers();
-    this.jar.applyToRequest(headers);
-    const response = await fetch(this.config.loginUrl, { headers });
-    this.jar.updateFromResponse(response.headers);
-    if (!response.ok) throw new Error(`Cronometer login page failed: ${response.status}`);
-    const text = await response.text();
-    const token = this.extractCsrf(text);
-    if (!token) throw new Error('Cronometer CSRF token not found on login page');
-    return token;
+    const urls = this.config.loginUrl.endsWith('/')
+      ? [this.config.loginUrl]
+      : [this.config.loginUrl, `${this.config.loginUrl}/`];
+
+    let lastStatus: number | null = null;
+    for (const url of urls) {
+      const headers = new Headers();
+      this.jar.applyToRequest(headers);
+      const response = await fetch(url, { headers });
+      this.jar.updateFromResponse(response.headers);
+      lastStatus = response.status;
+      if (!response.ok) continue;
+      const text = await response.text();
+      const token = this.extractCsrf(text);
+      if (token) return token;
+    }
+    if (lastStatus && lastStatus >= 400) {
+      throw new Error(`Cronometer login page failed: ${lastStatus}`);
+    }
+    throw new Error('Cronometer CSRF token not found on login page');
   }
 
   private extractCsrf(html: string): string | null {
@@ -223,12 +242,28 @@ export class CronometerAuthSession {
   }
 }
 
+function parseLoginResponse(
+  contentType: string | null,
+  body: string,
+): { success?: boolean; error?: string } | null {
+  const isJson = (contentType ?? '').toLowerCase().includes('application/json');
+  const trimmed = body.trim();
+  if (!isJson && !trimmed.startsWith('{')) return null;
+  try {
+    return JSON.parse(trimmed) as { success?: boolean; error?: string };
+  } catch {
+    return null;
+  }
+}
+
 function looksLikeLoginFailure(text: string): boolean {
   const lower = text.toLowerCase();
   return (
     lower.includes('invalid') ||
     lower.includes('incorrect') ||
     lower.includes('authentication failed') ||
+    lower.includes('too many attempts') ||
+    lower.includes('try again later') ||
     lower.includes('two-factor') ||
     lower.includes('mfa')
   );


### PR DESCRIPTION
## Summary

- Backports missing rate-limit detection from the legacy project into `client.ts` — prevents silent lockouts when Cronometer throttles login attempts
- Fixes `getCsrfToken()` to try `/login/` (trailing slash) when `/login` returns an empty body — a live Cronometer site change that broke auth entirely
- Adds a standalone smoke-test script (`scripts/test-cronometer.ts`) for validating credentials locally before activating the n8n Daily Collection workflow

## Changes

| File | Change |
|------|--------|
| `client.ts` | Add `parseLoginResponse()`, extend `looksLikeLoginFailure()`, update `ensureLogin()` + `getCsrfToken()` |
| `__tests__/client.test.ts` | New — 5 unit tests including CSRF fallback coverage |
| `scripts/test-cronometer.ts` | New — smoke-test script |
| `package.json` | Add `test:cronometer` script |
| `docs/architecture.md` | Document full 5-step Cronometer auth flow |
| `docs/plans/2026-03-13-cronometer-safety.md` | Mark success criteria complete, note trailing-slash discovery |

## Test plan

- [x] 157 backend unit tests pass (`npm test -w @vitals/backend`)
- [x] Smoke test executed against live Cronometer — returned real nutrition CSV for 2026-03-12 (2212 kcal)
- [x] Code reviewed — sanitized external error strings, added CSRF fallback test

🤖 Generated with [Claude Code](https://claude.com/claude-code)