### PR TITLE
feat: add Playwright E2E tests for dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ dist/
 # Git worktrees
 .worktrees/
 
+# Playwright
+playwright-report/
+test-results/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+import { DashboardPage } from './pages/dashboard.page';
+import { mockDashboardApi } from './fixtures/dashboard.fixture';
+
+test.describe('Dashboard', () => {
+  let dashboard: DashboardPage;
+
+  test.beforeEach(async ({ page }) => {
+    await mockDashboardApi(page);
+    dashboard = new DashboardPage(page);
+    await dashboard.goto();
+  });
+
+  test.describe('UC1: Default Dashboard view', () => {
+    test('displays the Dashboard heading', async () => {
+      await expect(dashboard.heading).toBeVisible();
+    });
+
+    test('renders Nutrition Trends chart', async () => {
+      await expect(dashboard.nutritionChart).toBeVisible();
+    });
+
+    test('renders Workout Volume chart', async () => {
+      await expect(dashboard.workoutVolumeChart).toBeVisible();
+    });
+
+    test('renders Body Weight chart', async () => {
+      await expect(dashboard.bodyWeightChart).toBeVisible();
+    });
+
+    test('renders weekly summary stats with computed values', async () => {
+      await expect(dashboard.avgCalories).toBeVisible();
+      await expect(dashboard.workoutSessions).toBeVisible();
+      await expect(dashboard.avgWeight).toBeVisible();
+
+      // Verify the stats show actual values (not dashes)
+      const calorieValue = dashboard.statValue('Avg Daily Calories');
+      await expect(calorieValue).toContainText('kcal');
+
+      const sessionValue = dashboard.statValue('Workout Sessions');
+      await expect(sessionValue).toContainText('2');
+
+      const weightValue = dashboard.statValue('Avg Weight');
+      await expect(weightValue).toContainText('kg');
+    });
+
+    test('renders Latest AI Report preview', async () => {
+      await expect(dashboard.latestReport).toBeVisible();
+
+      // Report summary text from fixture
+      await expect(
+        dashboard.page.getByText('Great progress this week'),
+      ).toBeVisible();
+
+      // Action items are shown
+      await expect(
+        dashboard.page.getByText('Increase fiber intake'),
+      ).toBeVisible();
+    });
+
+    test('displays all five widget sections on initial load', async () => {
+      // All five dashboard widgets should be present
+      await expect(dashboard.nutritionChart).toBeVisible();
+      await expect(dashboard.workoutVolumeChart).toBeVisible();
+      await expect(dashboard.bodyWeightChart).toBeVisible();
+      await expect(dashboard.avgCalories).toBeVisible();
+      await expect(dashboard.latestReport).toBeVisible();
+    });
+  });
+
+  test.describe('UC2: Custom date range selection', () => {
+    test('date range picker is visible and shows current range', async () => {
+      await expect(dashboard.datePickerTrigger).toBeVisible();
+      // Default range is 30 days — trigger should contain a date-like string
+      await expect(dashboard.datePickerTrigger).toContainText('—');
+    });
+
+    test('opening date picker shows a calendar popover', async ({ page }) => {
+      await dashboard.openDatePicker();
+
+      // Calendar component renders with data-slot="calendar"
+      const calendar = page.locator('[data-slot="calendar"]').first();
+      await expect(calendar).toBeVisible();
+    });
+
+    test('selecting a new date range triggers a data refresh', async ({ page }) => {
+      // Track API calls to verify refetch
+      const apiCalls: string[] = [];
+      page.on('request', (req) => {
+        if (req.url().includes('/api/dashboard/weekly')) {
+          apiCalls.push(req.url());
+        }
+      });
+
+      // Wait for initial load request
+      await page.waitForTimeout(500);
+      const initialCount = apiCalls.length;
+
+      // Open date picker
+      await dashboard.openDatePicker();
+      const calendar = page.locator('[data-slot="calendar"]').first();
+      await expect(calendar).toBeVisible();
+
+      // react-day-picker in range mode: clicking a single day sets from=to,
+      // which satisfies the handleSelect condition and closes the popover.
+      await calendar.getByRole('button', { name: /March 1st/ }).click();
+
+      // Popover should close and the date range trigger updates
+      await expect(dashboard.datePickerTrigger).toContainText('Mar 1');
+
+      // A new API call should have been made
+      expect(apiCalls.length).toBeGreaterThan(initialCount);
+    });
+
+    test('dashboard content updates after date range change', async ({ page }) => {
+      // After changing dates, the dashboard should still render all widgets
+      await dashboard.openDatePicker();
+      const calendar = page.locator('[data-slot="calendar"]').first();
+      await expect(calendar).toBeVisible();
+
+      // Select a single day — this changes the range and closes the popover
+      await calendar.getByRole('button', { name: /March 1st/ }).click();
+
+      // All widgets should still be visible after range change
+      await expect(dashboard.nutritionChart).toBeVisible();
+      await expect(dashboard.workoutVolumeChart).toBeVisible();
+      await expect(dashboard.bodyWeightChart).toBeVisible();
+      await expect(dashboard.avgCalories).toBeVisible();
+    });
+  });
+});

--- a/e2e/fixtures/dashboard.fixture.ts
+++ b/e2e/fixtures/dashboard.fixture.ts
@@ -1,0 +1,131 @@
+import type { Page } from '@playwright/test';
+import { format, subDays } from 'date-fns';
+
+const today = new Date();
+const fmt = (d: Date) => format(d, 'yyyy-MM-dd');
+
+function makeDashboardData(startDate: string, endDate: string) {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const days: string[] = [];
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    days.push(fmt(new Date(d)));
+  }
+
+  return {
+    data: {
+      nutrition: days.map((date, i) => ({
+        date,
+        calories: 2000 + i * 50,
+        protein: 120 + i * 2,
+        carbs: 220 + i * 5,
+        fat: 70 + i,
+        fiber: 25,
+      })),
+      workouts: [
+        {
+          id: 'session-1',
+          userId: 'user-1',
+          date: days[1] ?? startDate,
+          title: 'Upper Body',
+          durationSeconds: 3600,
+          source: 'strong',
+          collectedAt: startDate,
+          sets: [
+            {
+              id: 'set-1',
+              sessionId: 'session-1',
+              exerciseName: 'Bench Press',
+              setIndex: 1,
+              weightKg: 80,
+              reps: 10,
+              durationSeconds: null,
+              distanceMeters: null,
+              rpe: null,
+            },
+          ],
+        },
+        {
+          id: 'session-2',
+          userId: 'user-1',
+          date: days[3] ?? startDate,
+          title: 'Lower Body',
+          durationSeconds: 4200,
+          source: 'strong',
+          collectedAt: startDate,
+          sets: [
+            {
+              id: 'set-2',
+              sessionId: 'session-2',
+              exerciseName: 'Squat',
+              setIndex: 1,
+              weightKg: 100,
+              reps: 8,
+              durationSeconds: null,
+              distanceMeters: null,
+              rpe: null,
+            },
+          ],
+        },
+      ],
+      biometrics: days
+        .filter((_, i) => i % 2 === 0)
+        .map((date) => ({
+          id: `bio-${date}`,
+          userId: 'user-1',
+          date,
+          metric: 'weight_kg',
+          value: 82.5,
+          unit: 'kg',
+          source: 'apple_health',
+          collectedAt: date,
+        })),
+    },
+  };
+}
+
+const reportsFixture = {
+  data: [
+    {
+      id: 'report-1',
+      userId: 'user-1',
+      periodStart: fmt(subDays(today, 7)),
+      periodEnd: fmt(today),
+      summary: 'Great progress this week. Calorie targets met consistently.',
+      insights: 'Protein intake is strong. Consider adding more fiber.',
+      actionItems: [
+        { category: 'nutrition' as const, priority: 'high' as const, text: 'Increase fiber intake to 30g daily' },
+        { category: 'workout' as const, priority: 'medium' as const, text: 'Add a third leg day' },
+        { category: 'recovery' as const, priority: 'low' as const, text: 'Try foam rolling post-workout' },
+      ],
+      dataCoverage: { nutritionDays: 7, workoutDays: 3, biometricDays: 4 },
+      aiProvider: 'gemini',
+      aiModel: 'gemini-2.0-flash',
+      createdAt: fmt(today),
+    },
+  ],
+};
+
+/**
+ * Intercept all dashboard-related API calls with deterministic fixture data.
+ */
+export async function mockDashboardApi(page: Page) {
+  await page.route('**/api/dashboard/weekly*', async (route) => {
+    const url = new URL(route.request().url());
+    const startDate = url.searchParams.get('startDate') ?? fmt(subDays(today, 30));
+    const endDate = url.searchParams.get('endDate') ?? fmt(today);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(makeDashboardData(startDate, endDate)),
+    });
+  });
+
+  await page.route('**/api/reports', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(reportsFixture),
+    });
+  });
+}

--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -1,0 +1,70 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Page Object Model for the Dashboard page.
+ * Encapsulates selectors so tests stay readable and maintainable.
+ */
+export class DashboardPage {
+  readonly page: Page;
+
+  // Page heading
+  readonly heading: Locator;
+
+  // Chart cards (identified by their card titles)
+  readonly nutritionChart: Locator;
+  readonly workoutVolumeChart: Locator;
+  readonly bodyWeightChart: Locator;
+
+  // Weekly summary stat labels
+  readonly avgCalories: Locator;
+  readonly workoutSessions: Locator;
+  readonly avgWeight: Locator;
+
+  // Latest report
+  readonly latestReport: Locator;
+
+  // Date range picker (in the Topbar, contains "—" between dates)
+  readonly datePickerTrigger: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.heading = page.getByRole('heading', { name: 'Dashboard' });
+
+    this.nutritionChart = page.getByText('Nutrition Trends');
+    this.workoutVolumeChart = page.getByText('Workout Volume (kg)');
+    this.bodyWeightChart = page.getByText('Body Weight (kg)');
+
+    this.avgCalories = page.getByText('Avg Daily Calories');
+    this.workoutSessions = page.getByText('Workout Sessions');
+    this.avgWeight = page.getByText('Avg Weight');
+
+    this.latestReport = page.getByText('Latest AI Report');
+
+    // Desktop topbar date picker (the one with text-sm, not the compact mobile one)
+    this.datePickerTrigger = page
+      .locator('header [data-slot="popover-trigger"]')
+      .filter({ hasText: '—' })
+      .last();
+  }
+
+  async goto() {
+    await this.page.goto('/');
+  }
+
+  /** Open the date range popover */
+  async openDatePicker() {
+    await this.datePickerTrigger.click();
+  }
+
+  /** Get the value (bold number) inside a stat card by its label text */
+  statValue(label: string): Locator {
+    // Each stat is its own Card. Find the card that contains the label,
+    // then locate the bold value <p> within that specific card.
+    return this.page
+      .locator('[data-slot="card"]')
+      .filter({ hasText: label })
+      .locator('p.text-2xl')
+      .first();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.58.2",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
@@ -177,6 +178,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -749,6 +751,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -789,6 +792,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -968,7 +972,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -986,7 +989,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1004,7 +1006,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1022,7 +1023,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1040,7 +1040,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1058,7 +1057,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1076,7 +1074,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1094,7 +1091,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1112,7 +1108,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1130,7 +1125,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1148,7 +1142,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1166,7 +1159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1184,7 +1176,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1202,7 +1193,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1220,7 +1210,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1238,7 +1227,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1256,7 +1244,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1274,7 +1261,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1292,7 +1278,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1310,7 +1295,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1328,7 +1312,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1346,7 +1329,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1364,7 +1346,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1382,7 +1363,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1400,7 +1380,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1418,7 +1397,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2170,6 +2148,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2266,6 +2245,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3055,8 +3050,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3226,6 +3220,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3236,6 +3231,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3297,6 +3293,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3685,6 +3682,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3759,7 +3757,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4105,6 +4102,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5058,8 +5056,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5443,6 +5440,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6742,6 +6740,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7556,6 +7555,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8144,7 +8144,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8917,6 +8916,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9065,6 +9065,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -9199,7 +9246,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9214,8 +9260,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -9389,6 +9434,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9420,6 +9466,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11015,6 +11062,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11223,6 +11271,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12285,6 +12334,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,13 +16,16 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "npm run clean --workspaces --if-present"
+    "clean": "npm run clean --workspaces --if-present",
+    "test:e2e": "npx playwright test",
+    "test:e2e:ui": "npx playwright test --ui"
   },
   "engines": {
     "node": ">=20.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.58.2",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+    actionTimeout: 10_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -w @vitals/frontend',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary
- Add 11 Playwright E2E tests covering two dashboard use cases: default view (UC1) and custom date range selection (UC2)
- Implement Page Object Model pattern and API route mocking for fast, backend-independent tests
- Configure Playwright with webServer auto-start, CI-aware retries, and gitignore for report/result artifacts

## Test plan
- [x] All 11 tests pass locally (`npm run test:e2e`)
- [ ] Verify CI pipeline runs successfully
- [ ] Confirm `playwright-report/` and `test-results/` are properly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)