### PR TITLE
fix: remove duplicate CI runs on feature branches

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [master, 'feature/**']
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Remove `feature/**` from `push` trigger in CI/CD workflow
- `pull_request` trigger already covers feature branches with open PRs
- Prevents duplicate Build & Test and Deploy jobs from running simultaneously

## Test plan
- [ ] Verify this PR itself only triggers one CI run (not two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)