### PR TITLE
fix: prevent DATE column timezone shift in pg driver

### DIFF
--- a/packages/backend/src/db/pool.ts
+++ b/packages/backend/src/db/pool.ts
@@ -1,5 +1,10 @@
 import pg from 'pg';
 
+// Return DATE columns as plain strings (YYYY-MM-DD) instead of Date objects.
+// pg constructs Date at midnight local time, so toISOString() shifts the date
+// back by the UTC offset — causing off-by-one day bugs in non-UTC timezones.
+pg.types.setTypeParser(1082, (val) => val);
+
 const { Pool } = pg;
 
 let pool: pg.Pool | null = null;


### PR DESCRIPTION
## Summary

- `pg` returns `DATE` columns as JS `Date` objects at midnight local time. Calling `.toISOString()` converts to UTC, shifting the date back by the UTC offset — causing off-by-one day bugs in non-UTC timezones
- Set `pg.types.setTypeParser(1082, val => val)` in `pool.ts` to return DATE columns as raw `YYYY-MM-DD` strings, bypassing all timezone conversion
- Verified via live E2E: `period_start`/`period_end` on generated reports now correctly reflect the requested date range

## Affected columns
- `weekly_reports.period_start`, `weekly_reports.period_end`
- `DATE(measured_at) AS day` in nutrition queries
- `DATE(started_at) AS day` in workout queries

## Test plan
- [x] `npm run build -w @vitals/backend` passes
- [x] Live E2E: POST `/api/reports/generate` with `startDate: 2026-03-07` returns `periodStart: 2026-03-07` (not `2026-03-06`)
- [x] Playwright UI test: report generation dialog flow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)