### PR TITLE
refactor: rename N8N_API_KEY to X_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ DATABASE_URL=postgresql://vitals:vitals@localhost:5432/vitals
 AI_PROVIDER=claude
 AI_API_KEY=your-api-key-here
 
-# n8n webhook security
-N8N_API_KEY=change-me
+# Shared API key — sent by frontend as x-api-key header, validated by backend
+X_API_KEY=change-me
 
 # Cronometer (legacy scraper)
 CRONOMETER_USERNAME=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@
 - **Route registration:** In `app.ts` via `await app.register(routes, { env })`
 - **DB access:** `app.db` (pg.Pool decorated via `plugins/database.ts`)
 - **DB queries:** Direct parameterized SQL via pg Pool — no ORM
-- **Protected routes:** `preHandler: apiKeyMiddleware(opts.env.n8nApiKey)`
+- **Protected routes:** `preHandler: apiKeyMiddleware(opts.env.xApiKey)`
 - **Env config:** All env vars in `EnvConfig` interface (`config/env.ts`), loaded via `loadEnv()`
 - **Normalizers:** Input `Record<string, unknown>` → output typed Row (`MeasurementRow`, `WorkoutSetRow`)
 - **Ingest:** 500-row batch INSERT with `ON CONFLICT DO UPDATE` for idempotent upserts

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -16,7 +16,7 @@ export interface EnvConfig {
   databaseUrl: string;
   aiProvider: 'claude' | 'gemini';
   aiApiKey: string;
-  n8nApiKey: string;
+  xApiKey: string;
   dbDefaultUserId: string;
   nodeEnv: string;
   frontendUrl: string;
@@ -36,7 +36,7 @@ export function loadEnv(): EnvConfig {
     databaseUrl: process.env.DATABASE_URL || 'postgresql://vitals:vitals@localhost:5432/vitals',
     aiProvider: validateAiProvider(process.env.AI_PROVIDER || 'claude'),
     aiApiKey: process.env.AI_API_KEY || '',
-    n8nApiKey: process.env.N8N_API_KEY || '',
+    xApiKey: process.env.X_API_KEY || '',
     dbDefaultUserId: process.env.DB_DEFAULT_USER_ID || '00000000-0000-0000-0000-000000000001',
     nodeEnv: process.env.NODE_ENV || 'development',
     frontendUrl: (process.env.FRONTEND_URL || '').trim(),

--- a/packages/backend/src/routes/__tests__/collect.test.ts
+++ b/packages/backend/src/routes/__tests__/collect.test.ts
@@ -28,7 +28,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: 'test-api-key',
+  xApiKey: 'test-api-key',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',
@@ -122,7 +122,7 @@ describe('POST /api/collect', () => {
   });
 
   it('allows request when no API key is configured (dev mode)', async () => {
-    const openEnv = { ...testEnv, n8nApiKey: '' };
+    const openEnv = { ...testEnv, xApiKey: '' };
     const app = await buildTestApp(openEnv);
     const response = await app.inject({
       method: 'POST',

--- a/packages/backend/src/routes/__tests__/dashboard.test.ts
+++ b/packages/backend/src/routes/__tests__/dashboard.test.ts
@@ -27,7 +27,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/__tests__/health.test.ts
+++ b/packages/backend/src/routes/__tests__/health.test.ts
@@ -13,7 +13,7 @@ const testEnv = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/__tests__/measurements.test.ts
+++ b/packages/backend/src/routes/__tests__/measurements.test.ts
@@ -33,7 +33,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/__tests__/nutrition.test.ts
+++ b/packages/backend/src/routes/__tests__/nutrition.test.ts
@@ -26,7 +26,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/__tests__/reports.test.ts
+++ b/packages/backend/src/routes/__tests__/reports.test.ts
@@ -44,7 +44,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: 'test-key',
-  n8nApiKey: 'test-api-key',
+  xApiKey: 'test-api-key',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/__tests__/upload.test.ts
+++ b/packages/backend/src/routes/__tests__/upload.test.ts
@@ -37,7 +37,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/__tests__/workouts.test.ts
+++ b/packages/backend/src/routes/__tests__/workouts.test.ts
@@ -41,7 +41,7 @@ const testEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: '',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',

--- a/packages/backend/src/routes/collect.ts
+++ b/packages/backend/src/routes/collect.ts
@@ -8,7 +8,7 @@ import { validateDateRange, isDateRangeError } from '../utils/validate-dates.js'
 export async function collectRoutes(app: FastifyInstance, opts: { env: EnvConfig }): Promise<void> {
   app.post<{ Body: CollectRequest }>(
     '/api/collect',
-    { preHandler: apiKeyMiddleware(opts.env.n8nApiKey) },
+    { preHandler: apiKeyMiddleware(opts.env.xApiKey) },
     async (request, reply) => {
       const { startDate, endDate, providers } = request.body ?? {};
       const range = validateDateRange(startDate, endDate);

--- a/packages/backend/src/routes/reports.ts
+++ b/packages/backend/src/routes/reports.ts
@@ -10,7 +10,7 @@ import { createAIProvider } from '../services/ai/ai-service.js';
 export async function reportRoutes(app: FastifyInstance, opts: { env: EnvConfig }): Promise<void> {
   app.post<{ Body: GenerateReportRequest }>(
     '/api/reports/generate',
-    { preHandler: apiKeyMiddleware(opts.env.n8nApiKey) },
+    { preHandler: apiKeyMiddleware(opts.env.xApiKey) },
     async (request, reply) => {
       const { startDate, endDate } = request.body ?? {};
       const range = validateDateRange(startDate, endDate);

--- a/packages/backend/src/services/ai/__tests__/ai-service.test.ts
+++ b/packages/backend/src/services/ai/__tests__/ai-service.test.ts
@@ -19,7 +19,7 @@ const baseEnv: EnvConfig = {
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
   aiProvider: 'claude' as const,
   aiApiKey: 'test-api-key',
-  n8nApiKey: '',
+  xApiKey: '',
   dbDefaultUserId: '00000000-0000-0000-0000-000000000001',
   nodeEnv: 'test',
   cronometerUsername: '',


### PR DESCRIPTION
## Summary

- Renamed env var `N8N_API_KEY` → `X_API_KEY` — the key is a generic shared secret between frontend and backend, not n8n-specific
- Renamed `EnvConfig.n8nApiKey` → `xApiKey` in backend config and all call sites
- Updated `.env.example` with clarifying comment
- Updated `CLAUDE.md`

## Deployment action required
- **Railway:** rename `N8N_API_KEY` → `X_API_KEY` in environment variables
- **Vercel:** `VITE_X_API_KEY` already uses the correct name — no change needed

## Test plan
- [x] `npm run build -w @vitals/backend` passes
- [x] 162/162 backend tests pass
- [x] 0 lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)