### PR TITLE
fix: add pre-collection to report generation (#26)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ src/
 │   └── api-key.ts        X-API-Key header guard
 ├── routes/               Fastify route plugins
 │   ├── health.ts         GET /health
-│   ├── collect.ts        POST /api/collect
+│   ├── collect.ts        POST /api/collect, GET /api/collect/status
 │   ├── nutrition.ts      GET /api/nutrition/daily        (Phase 3)
 │   ├── measurements.ts   GET /api/measurements           (Phase 3)
 │   ├── workouts.ts       GET /api/workouts               (Phase 3)
@@ -169,6 +169,7 @@ Query Layer (parallel)
 |--------|------|------|--------|
 | GET | `/health` | None | Live |
 | POST | `/api/collect` | X-API-Key | Live |
+| GET | `/api/collect/status` | X-API-Key | Live |
 | GET | `/api/nutrition/daily` | None | Phase 3 |
 | GET | `/api/measurements` | None | Phase 3 |
 | GET | `/api/workouts` | None | Phase 3 |

--- a/docs/plans/2026-03-16-report-pre-collection.md
+++ b/docs/plans/2026-03-16-report-pre-collection.md
@@ -1,0 +1,54 @@
+# Report Pre-Collection & Collection Status
+
+**Date:** 2026-03-16
+**Type:** bugfix + enhancement
+**Ref:** docs/plans/2026-03-16-debug-report-data-collection.md
+
+## Problem
+
+Report generation only queries existing DB data. If the n8n daily collection schedule fails, reports contain empty/stale data.
+
+## Solution
+
+### Phase 2: Pre-collection in report generation
+
+**File:** `packages/backend/src/routes/reports.ts`
+- After date validation, before AI provider creation, call `runCollection()` with the report's date range
+- Best-effort: catch errors, log them, continue with existing data
+- Providers are already registered at app startup in `app.ts:32`
+
+### Phase 3: Collection status endpoint + frontend warning
+
+**Backend — `packages/backend/src/routes/collect.ts`:**
+- Add `GET /api/collect/status` endpoint (API key protected)
+- Query `collection_metadata` table for all providers for the default user
+- Return array of `CollectionStatus` objects
+
+**Shared — `packages/shared/src/`:**
+- Add `CollectionStatus` interface
+- Add `collection` query key to `QUERY_KEYS`
+
+**Frontend:**
+- Add `useCollectionStatus` hook in `packages/frontend/src/api/hooks/useCollectionStatus.ts`
+- Add `StaleDataWarning` component — inline banner shown when any provider's last successful fetch > 24h ago
+- Render in `ReportsPage.tsx` above the reports list
+
+## Files to Modify/Create
+
+| File | Action |
+|------|--------|
+| `packages/backend/src/routes/reports.ts` | Add runCollection call |
+| `packages/backend/src/routes/collect.ts` | Add GET /api/collect/status |
+| `packages/backend/src/db/helpers.ts` | Add loadAllCollectionMetadata query |
+| `packages/shared/src/constants/query-keys.ts` | Add collection key |
+| `packages/shared/src/interfaces/` | Add CollectionStatus type + export |
+| `packages/frontend/src/api/hooks/useCollectionStatus.ts` | New hook |
+| `packages/frontend/src/components/reports/StaleDataWarning.tsx` | New component |
+| `packages/frontend/src/components/reports/ReportsPage.tsx` | Add warning |
+
+## Test Strategy
+
+- Unit test: reports route pre-collection (mock runCollection, verify it's called)
+- Unit test: collect status endpoint
+- Unit test: StaleDataWarning renders/hides based on data
+- Existing tests must continue to pass

--- a/docs/product-capabilities.md
+++ b/docs/product-capabilities.md
@@ -72,6 +72,8 @@ and biometrics (Apple Health) in a single unified dashboard.
 | UC-RPT-04 | Generate from dashboard widget | Implemented |
 | UC-RPT-05 | Structured 8-section health analysis | Implemented |
 | UC-RPT-06 | Add user notes to report generation | Implemented |
+| UC-RPT-07 | Pre-collection before report generation | Implemented |
+| UC-RPT-08 | Stale data warning on reports page | Implemented |
 
 ### UC-RPT-01: Generate weekly insights (first report)
 
@@ -176,6 +178,28 @@ The date range picker on other pages is irrelevant to report generation.
 - Confirm button adapts: "Generate" vs "Re-Generate"
 
 **E2E Coverage:** `e2e/reports.spec.ts` — user notes tests in both generate and re-generate sections
+
+### UC-RPT-07: Pre-collection before report generation
+
+**As a** user, **I want** report generation to automatically collect fresh data from all providers,
+**so that** my reports aren't empty when the scheduled collection pipeline hasn't run.
+
+**Behavior:**
+- Before querying the database, the report generation endpoint calls `runCollection()` with the report's date range
+- Collection is best-effort: if any provider fails, the error is logged and report generation continues with existing data
+- Collection results (total records, duration) are logged for debugging
+
+### UC-RPT-08: Stale data warning on reports page
+
+**As a** user, **I want to** see a warning when my data sources haven't synced recently,
+**so that** I know reports may contain incomplete data.
+
+**Behavior:**
+- Reports page shows a yellow warning banner when any provider's last successful sync was over 24 hours ago
+- Providers that have never been attempted are not flagged (only attempted-but-failed or stale providers)
+- Warning lists the affected provider names
+- A `GET /api/collect/status` endpoint returns collection metadata per provider
+- Raw error messages are sanitized before being returned to the client
 
 ---
 

--- a/packages/backend/src/db/helpers.ts
+++ b/packages/backend/src/db/helpers.ts
@@ -64,6 +64,30 @@ export async function saveCollectionMetadata(
   );
 }
 
+export async function loadAllCollectionMetadata(
+  pool: pg.Pool,
+  userId: string,
+): Promise<CollectionMetadata[]> {
+  const { rows } = await pool.query(
+    `SELECT user_id, provider_name, last_successful_fetch, last_attempted_fetch,
+            record_count, status, error_message
+     FROM collection_metadata
+     WHERE user_id = $1
+     ORDER BY provider_name`,
+    [userId],
+  );
+
+  return rows.map((r) => ({
+    userId: r.user_id,
+    providerName: r.provider_name,
+    lastSuccessfulFetch: r.last_successful_fetch,
+    lastAttemptedFetch: r.last_attempted_fetch,
+    recordCount: r.record_count,
+    status: r.status,
+    errorMessage: r.error_message,
+  }));
+}
+
 export async function refreshDailyAggregates(pool: pg.Pool): Promise<void> {
   await pool.query('REFRESH MATERIALIZED VIEW CONCURRENTLY daily_aggregates');
 }

--- a/packages/backend/src/routes/__tests__/collect.test.ts
+++ b/packages/backend/src/routes/__tests__/collect.test.ts
@@ -23,6 +23,30 @@ vi.mock('../../services/collectors/register.js', () => ({
   registerProviders: vi.fn(),
 }));
 
+// Mock DB helpers for status endpoint
+vi.mock('../../db/helpers.js', () => ({
+  loadAllCollectionMetadata: vi.fn().mockResolvedValue([]),
+  loadCollectionMetadata: vi.fn().mockResolvedValue(null),
+  saveCollectionMetadata: vi.fn().mockResolvedValue(undefined),
+  refreshDailyAggregates: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock report queries (needed for app build)
+vi.mock('../../db/queries/reports.js', () => ({
+  listReports: vi.fn().mockResolvedValue([]),
+  getReportById: vi.fn().mockResolvedValue(null),
+  saveReport: vi.fn().mockResolvedValue('new-uuid'),
+  logAiGeneration: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/ai/report-generator.js', () => ({
+  generateWeeklyReport: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../services/ai/ai-service.js', () => ({
+  createAIProvider: vi.fn().mockReturnValue({ name: () => 'claude', complete: vi.fn() }),
+}));
+
 const testEnv: EnvConfig = {
   port: 3001,
   databaseUrl: 'postgresql://test:test@localhost:5432/test',
@@ -131,6 +155,71 @@ describe('POST /api/collect', () => {
       body: JSON.stringify({ startDate: '2026-03-01', endDate: '2026-03-07' }),
     });
     expect(response.statusCode).toBe(200);
+    await app.close();
+  });
+});
+
+describe('GET /api/collect/status', () => {
+  it('returns 401 when API key is missing', async () => {
+    const app = await buildTestApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/collect/status',
+    });
+    expect(response.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('returns 200 with empty array when no metadata exists', async () => {
+    const app = await buildTestApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/collect/status',
+      headers: { 'x-api-key': 'test-api-key' },
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.data).toEqual([]);
+    await app.close();
+  });
+
+  it('returns collection status for all providers', async () => {
+    const { loadAllCollectionMetadata } = await import('../../db/helpers.js');
+    (loadAllCollectionMetadata as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        userId: testEnv.dbDefaultUserId,
+        providerName: 'hevy',
+        lastSuccessfulFetch: new Date('2026-03-15T10:00:00Z'),
+        lastAttemptedFetch: new Date('2026-03-15T10:00:00Z'),
+        recordCount: 42,
+        status: 'success',
+        errorMessage: null,
+      },
+      {
+        userId: testEnv.dbDefaultUserId,
+        providerName: 'cronometer-nutrition',
+        lastSuccessfulFetch: null,
+        lastAttemptedFetch: new Date('2026-03-14T06:00:00Z'),
+        recordCount: 0,
+        status: 'error',
+        errorMessage: 'Auth failed',
+      },
+    ]);
+
+    const app = await buildTestApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/collect/status',
+      headers: { 'x-api-key': 'test-api-key' },
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].providerName).toBe('hevy');
+    expect(body.data[0].lastSuccessfulFetch).toBe('2026-03-15T10:00:00.000Z');
+    expect(body.data[0].recordCount).toBe(42);
+    expect(body.data[1].providerName).toBe('cronometer-nutrition');
+    expect(body.data[1].errorMessage).toBe('Collection error occurred');
     await app.close();
   });
 });

--- a/packages/backend/src/routes/__tests__/reports.test.ts
+++ b/packages/backend/src/routes/__tests__/reports.test.ts
@@ -12,6 +12,14 @@ vi.mock('../../services/collectors/register.js', () => ({
   registerProviders: vi.fn(),
 }));
 
+vi.mock('../../services/collectors/pipeline.js', () => ({
+  runCollection: vi.fn().mockResolvedValue({
+    results: [],
+    totalRecords: 0,
+    durationMs: 50,
+  }),
+}));
+
 vi.mock('../../db/queries/reports.js', () => ({
   listReports: vi.fn().mockResolvedValue([]),
   getReportById: vi.fn().mockResolvedValue(null),
@@ -196,6 +204,46 @@ describe('POST /api/reports/generate', () => {
       headers: { 'x-api-key': 'test-api-key', 'content-type': 'application/json' },
       body: JSON.stringify({ startDate: '2026-03-01', endDate: '2026-03-07' }),
     });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.data.summary).toBe('Great week!');
+    await app.close();
+  });
+
+  it('calls runCollection before generating the report', async () => {
+    const { runCollection } = await import('../../services/collectors/pipeline.js');
+    (runCollection as ReturnType<typeof vi.fn>).mockClear();
+
+    const app = await buildApp(testEnv);
+    await app.inject({
+      method: 'POST',
+      url: '/api/reports/generate',
+      headers: { 'x-api-key': 'test-api-key', 'content-type': 'application/json' },
+      body: JSON.stringify({ startDate: '2026-03-01', endDate: '2026-03-07' }),
+    });
+
+    expect(runCollection).toHaveBeenCalledOnce();
+    const callArgs = (runCollection as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[1]).toMatchObject({
+      userId: testEnv.dbDefaultUserId,
+    });
+    await app.close();
+  });
+
+  it('still generates report when pre-collection fails', async () => {
+    const { runCollection } = await import('../../services/collectors/pipeline.js');
+    (runCollection as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Cronometer auth failed'),
+    );
+
+    const app = await buildApp(testEnv);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports/generate',
+      headers: { 'x-api-key': 'test-api-key', 'content-type': 'application/json' },
+      body: JSON.stringify({ startDate: '2026-03-01', endDate: '2026-03-07' }),
+    });
+
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body.data.summary).toBe('Great week!');

--- a/packages/backend/src/routes/collect.ts
+++ b/packages/backend/src/routes/collect.ts
@@ -1,8 +1,9 @@
 import type { FastifyInstance } from 'fastify';
-import type { CollectRequest } from '@vitals/shared';
+import type { CollectRequest, CollectionStatus } from '@vitals/shared';
 import type { EnvConfig } from '../config/env.js';
 import { apiKeyMiddleware } from '../middleware/api-key.js';
 import { runCollection } from '../services/collectors/pipeline.js';
+import { loadAllCollectionMetadata } from '../db/helpers.js';
 import { validateDateRange, isDateRangeError } from '../utils/validate-dates.js';
 
 export async function collectRoutes(app: FastifyInstance, opts: { env: EnvConfig }): Promise<void> {
@@ -29,6 +30,23 @@ export async function collectRoutes(app: FastifyInstance, opts: { env: EnvConfig
       });
 
       return reply.code(200).send({ success: true, data: result });
+    },
+  );
+
+  app.get(
+    '/api/collect/status',
+    { preHandler: apiKeyMiddleware(opts.env.xApiKey) },
+    async (_request, reply) => {
+      const rows = await loadAllCollectionMetadata(app.db, opts.env.dbDefaultUserId);
+      const data: CollectionStatus[] = rows.map((r) => ({
+        providerName: r.providerName,
+        lastSuccessfulFetch: r.lastSuccessfulFetch?.toISOString() ?? null,
+        lastAttemptedFetch: r.lastAttemptedFetch?.toISOString() ?? null,
+        recordCount: r.recordCount,
+        status: r.status,
+        errorMessage: r.errorMessage ? 'Collection error occurred' : null,
+      }));
+      return reply.code(200).send({ data });
     },
   );
 }

--- a/packages/backend/src/routes/reports.ts
+++ b/packages/backend/src/routes/reports.ts
@@ -6,6 +6,7 @@ import { validateDateRange, isDateRangeError } from '../utils/validate-dates.js'
 import { getReportById, listReports } from '../db/queries/reports.js';
 import { generateWeeklyReport } from '../services/ai/report-generator.js';
 import { createAIProvider } from '../services/ai/ai-service.js';
+import { runCollection } from '../services/collectors/pipeline.js';
 
 export async function reportRoutes(app: FastifyInstance, opts: { env: EnvConfig }): Promise<void> {
   app.post<{ Body: GenerateReportRequest }>(
@@ -21,6 +22,24 @@ export async function reportRoutes(app: FastifyInstance, opts: { env: EnvConfig 
           message: range.error,
           statusCode: 400,
         });
+      }
+
+      // Best-effort data collection before report generation
+      try {
+        const collectionResult = await runCollection(app.db, {
+          userId: opts.env.dbDefaultUserId,
+          startDate: range.start,
+          endDate: range.end,
+        });
+        request.log.info(
+          { totalRecords: collectionResult.totalRecords, durationMs: collectionResult.durationMs },
+          'Pre-report data collection completed',
+        );
+      } catch (err: unknown) {
+        request.log.warn(
+          { err },
+          'Pre-report data collection failed (continuing with existing data)',
+        );
       }
 
       let aiProvider;

--- a/packages/frontend/src/api/hooks/useCollectionStatus.ts
+++ b/packages/frontend/src/api/hooks/useCollectionStatus.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ApiResponse, CollectionStatus } from '@vitals/shared';
+import { QUERY_KEYS } from '@vitals/shared';
+import { apiFetch } from '../client';
+
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function isProviderStale(s: CollectionStatus): boolean {
+  if (!s.lastAttemptedFetch) return false; // never attempted — not a staleness issue
+  if (!s.lastSuccessfulFetch) return true; // attempted but never succeeded
+  return Date.now() - new Date(s.lastSuccessfulFetch).getTime() > STALE_THRESHOLD_MS;
+}
+
+export function useCollectionStatus() {
+  return useQuery({
+    queryKey: QUERY_KEYS.collection.status,
+    queryFn: () =>
+      apiFetch<ApiResponse<CollectionStatus[]>>('/api/collect/status', {
+        headers: { 'x-api-key': import.meta.env.VITE_X_API_KEY ?? '' },
+      }),
+    staleTime: STALE_THRESHOLD_MS, // 24 hours — matches the staleness threshold
+    select: (res) => ({
+      statuses: res.data,
+      staleProviders: res.data.filter(isProviderStale),
+    }),
+  });
+}

--- a/packages/frontend/src/components/reports/ReportsPage.tsx
+++ b/packages/frontend/src/components/reports/ReportsPage.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { useReports, useGenerateReport } from '@/api/hooks/useReports';
 import { ReportCard } from './ReportCard';
 import { GenerateReportDialog } from './GenerateReportDialog';
+import { StaleDataWarning } from './StaleDataWarning';
 import { CardSkeleton } from '@/components/ui/LoadingSkeleton';
 import { Button } from '@/components/ui/button';
 
@@ -47,6 +48,8 @@ export function ReportsPage() {
           )}
         </Button>
       </div>
+
+      <StaleDataWarning />
 
       {error && <p className="text-sm text-destructive">Failed to load reports.</p>}
 

--- a/packages/frontend/src/components/reports/StaleDataWarning.tsx
+++ b/packages/frontend/src/components/reports/StaleDataWarning.tsx
@@ -1,0 +1,21 @@
+import { AlertTriangle } from 'lucide-react';
+import { useCollectionStatus } from '@/api/hooks/useCollectionStatus';
+
+export function StaleDataWarning() {
+  const { data } = useCollectionStatus();
+  const staleProviders = data?.staleProviders ?? [];
+
+  if (staleProviders.length === 0) return null;
+
+  const names = staleProviders.map((s) => s.providerName).join(', ');
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-700 dark:text-yellow-400">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <span>
+        Data may be stale for: <strong>{names}</strong>. Last sync was over 24 hours ago. Reports
+        will attempt to collect fresh data before generating.
+      </span>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/reports/__tests__/StaleDataWarning.test.tsx
+++ b/packages/frontend/src/components/reports/__tests__/StaleDataWarning.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StaleDataWarning } from '../StaleDataWarning';
+import * as client from '@/api/client';
+
+vi.mock('@/api/client');
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('StaleDataWarning', () => {
+  it('renders nothing when all providers are fresh', async () => {
+    vi.mocked(client.apiFetch).mockResolvedValueOnce({
+      data: [
+        {
+          providerName: 'hevy',
+          lastSuccessfulFetch: new Date().toISOString(),
+          lastAttemptedFetch: new Date().toISOString(),
+          recordCount: 10,
+          status: 'success',
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const { container } = render(<StaleDataWarning />, { wrapper });
+    // Wait for query to resolve, then check no warning rendered
+    await vi.waitFor(() => {
+      expect(container.querySelector('.bg-yellow-500\\/10')).toBeNull();
+    });
+  });
+
+  it('renders warning when a provider is stale', async () => {
+    const staleDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25h ago
+    vi.mocked(client.apiFetch).mockResolvedValueOnce({
+      data: [
+        {
+          providerName: 'cronometer-nutrition',
+          lastSuccessfulFetch: staleDate,
+          lastAttemptedFetch: staleDate,
+          recordCount: 5,
+          status: 'success',
+          errorMessage: null,
+        },
+      ],
+    });
+
+    render(<StaleDataWarning />, { wrapper });
+    await screen.findByText(/Data may be stale/);
+    expect(screen.getByText('cronometer-nutrition')).toBeDefined();
+  });
+
+  it('renders nothing when a provider has never been attempted', async () => {
+    vi.mocked(client.apiFetch).mockResolvedValueOnce({
+      data: [
+        {
+          providerName: 'hevy',
+          lastSuccessfulFetch: null,
+          lastAttemptedFetch: null,
+          recordCount: 0,
+          status: 'idle',
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const { container } = render(<StaleDataWarning />, { wrapper });
+    await vi.waitFor(() => {
+      expect(container.querySelector('.bg-yellow-500\\/10')).toBeNull();
+    });
+  });
+
+  it('renders warning when a provider was attempted but never succeeded', async () => {
+    vi.mocked(client.apiFetch).mockResolvedValueOnce({
+      data: [
+        {
+          providerName: 'cronometer-nutrition',
+          lastSuccessfulFetch: null,
+          lastAttemptedFetch: new Date().toISOString(),
+          recordCount: 0,
+          status: 'error',
+          errorMessage: 'Collection error occurred',
+        },
+      ],
+    });
+
+    render(<StaleDataWarning />, { wrapper });
+    await screen.findByText(/Data may be stale/);
+  });
+});

--- a/packages/shared/src/constants/query-keys.ts
+++ b/packages/shared/src/constants/query-keys.ts
@@ -20,4 +20,7 @@ export const QUERY_KEYS = {
   dashboard: {
     weekly: (start: string, end: string) => ['dashboard', 'weekly', start, end] as const,
   },
+  collection: {
+    status: ['collection', 'status'] as const,
+  },
 } as const;

--- a/packages/shared/src/interfaces/api.ts
+++ b/packages/shared/src/interfaces/api.ts
@@ -26,3 +26,12 @@ export interface GenerateReportRequest extends DateRangeParams {
   userNotes?: string;
   workoutPlan?: string;
 }
+
+export interface CollectionStatus {
+  providerName: string;
+  lastSuccessfulFetch: string | null;
+  lastAttemptedFetch: string | null;
+  recordCount: number;
+  status: string;
+  errorMessage: string | null;
+}


### PR DESCRIPTION
## Summary
- Report generation now calls `runCollection()` before DB queries, ensuring fresh data even when the n8n daily schedule hasn't run (best-effort — failures logged, generation continues)
- New `GET /api/collect/status` endpoint returns per-provider collection metadata (API key protected)
- New `StaleDataWarning` component on Reports page alerts when any provider's last sync exceeds 24h
- Raw error messages sanitized before client exposure (security fix)

**Use cases:** UC-RPT-07 (pre-collection), UC-RPT-08 (stale data warning)

## Test plan
- [x] Backend: 173 tests pass (2 new pre-collection tests + 3 new status endpoint tests)
- [x] Frontend: 20 tests pass (4 new StaleDataWarning tests)
- [x] E2E: 29 tests pass
- [x] Lint: 0 errors
- [x] Format: clean

**Spec:** `docs/plans/2026-03-16-debug-report-data-collection.md`
**Plan:** `docs/plans/2026-03-16-report-pre-collection.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)