### PR TITLE
fix: remove duplicate workout rows inflating volumes

### DIFF
--- a/docs/plans/2026-03-17-cleanup-duplicate-workout-rows.md
+++ b/docs/plans/2026-03-17-cleanup-duplicate-workout-rows.md
@@ -1,0 +1,38 @@
+# Cleanup Duplicate Workout Rows
+
+**Date:** 2026-03-17
+**Type:** Bugfix
+**Status:** Planned
+
+## Context
+
+After fixing the exercise name fallback chain (PR #29), re-collection from Hevy created correct rows
+alongside old rows that used workout titles as exercise names. The upsert key includes `exercise_name`,
+so old rows (`"Legs"`, `"Push"`, `"Pull"`, `"Upper"`) don't conflict with new correct rows — both exist,
+inflating volumes by ~25%.
+
+## Tasks
+
+1. Add migration 005 to delete rows where `exercise_name` is a known workout title
+2. Verify locally with live UI screenshots
+3. Deploy and verify on production
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `packages/backend/src/db/migrations/005_cleanup_workout_title_rows.sql` | Create | DELETE stale rows |
+
+## Dependencies
+
+None.
+
+## Test Strategy
+
+- Live local UI verification with Playwright screenshots
+- Compare volume numbers before/after cleanup against Hevy evidence
+
+## Risks
+
+- Migration is destructive (DELETE) — but these rows are confirmed duplicates
+- Only targets `source = 'hevy'` rows with exact workout title matches

--- a/packages/backend/src/db/migrations/005_cleanup_workout_title_rows.sql
+++ b/packages/backend/src/db/migrations/005_cleanup_workout_title_rows.sql
@@ -1,0 +1,6 @@
+-- Remove duplicate workout sets where exercise_name was incorrectly set to the workout title.
+-- These rows were created before the exercise name fallback fix (PR #29) and coexist
+-- alongside correct rows from re-collection, inflating volume calculations.
+DELETE FROM workout_sets
+WHERE source = 'hevy'
+  AND exercise_name IN ('Legs', 'Push', 'Pull', 'Upper');


### PR DESCRIPTION
## Summary
- Old rows from before the exercise name fix (PR #29) persisted alongside correct re-collected rows
- Rows with `exercise_name` set to workout titles (`Legs`, `Push`, `Pull`, `Upper`) coexisted with correct exercise names, inflating volumes by ~25%
- Migration 005 deletes these duplicate rows (`source = 'hevy'` only)

## Evidence
- **Before cleanup:** Mar 14 session showed 16,320 kg (29 sets, includes "Legs" duplicates)
- **After cleanup:** Mar 14 session showed 12,882 kg (21 sets, only real exercises)
- **Hevy reference:** Mar 14 = 13,680 kg (local test data approximated, minor diff expected)

## Test plan
- [x] Bug reproduced on live local UI with screenshot
- [x] Fix verified on live local UI with screenshot
- [x] All 208 unit tests pass
- [x] Lint passes with 0 errors
- [ ] After deploy: verify production volumes match Hevy

🤖 Generated with [Claude Code](https://claude.com/claude-code)