### PR TITLE
feat: pre-push code review hook via pr-review-toolkit

### DIFF
--- a/.claude/hooks/pre-push-review.sh
+++ b/.claude/hooks/pre-push-review.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# pre-push-review.sh
+#
+# PreToolUse hook: intercepts `git push` (non-main branches) and `gh pr create`.
+# Collects the branch diff and injects context instructing Claude to automatically
+# run pr-review-toolkit:code-reviewer, then ask the user whether to fix issues first.
+#
+# Input:  JSON on stdin  { "tool_name": "Bash", "tool_input": { "command": "..." } }
+# Output: JSON on stdout with hookSpecificOutput.additionalContext
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only intercept push / PR creation
+IS_PUSH=false
+IS_PR=false
+echo "$COMMAND" | grep -qE 'git\s+push' && IS_PUSH=true || true
+echo "$COMMAND" | grep -qE 'gh\s+pr\s+create' && IS_PR=true || true
+
+if [ "$IS_PUSH" = false ] && [ "$IS_PR" = false ]; then
+  exit 0
+fi
+
+# For git push: skip main/master (not a PR workflow)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+if [ "$IS_PUSH" = true ] && { [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; }; then
+  exit 0
+fi
+
+# Collect diff context
+CHANGED_FILES=$(git diff --name-only master..."$BRANCH" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+DIFF_STAT=$(git diff --stat master..."$BRANCH" 2>/dev/null || git diff --stat HEAD~1 2>/dev/null || echo "")
+
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+# Build the context message injected back into Claude
+CONTEXT="AUTOMATIC CODE REVIEW REQUIRED
+
+The user is about to run: $COMMAND
+Branch: $BRANCH
+
+Changed files:
+$CHANGED_FILES
+
+Diff summary:
+$DIFF_STAT
+
+ACTION REQUIRED (do this now, automatically — do not wait for user instruction):
+1. Invoke the pr-review-toolkit:code-reviewer agent on the diff for branch '$BRANCH' vs master.
+2. After the review completes, present the findings to the user.
+3. If issues were found, ask the user: 'The review found [N] issue(s). Would you like me to fix them before pushing?'
+4. If the user says yes — fix the issues, then re-run the original command.
+5. If the user says no — proceed with the original command immediately."
+
+# Output: allow the command but inject context so Claude runs the review
+printf '%s' "$CONTEXT" | jq -Rs '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "allow",
+    additionalContext: .
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,19 @@
     "superpowers@claude-plugins-official": true
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-push-review.sh",
+            "timeout": 300,
+            "statusMessage": "Running code review before push/PR..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "Bash(gh api repos/silver-snoopy/health-analysis/contents/src/core/services/cronometer_service.ts --jq '.content')",
       "Bash(gh api repos/silver-snoopy/health-analysis/contents/src/core/services/hevy_service.ts --jq '.content')",
-      "Bash(node -e \":*)"
+      "Bash(node -e \":*)",
+      "Skill(update-config)",
+      "Skill(update-config:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` Bash hook that intercepts `git push` (feature branches) and `gh pr create`
- Automatically triggers `pr-review-toolkit:code-reviewer` by injecting `additionalContext` into Claude's context
- Non-blocking: push proceeds but Claude surfaces findings and asks the user whether to fix issues first

## How it works
1. `pre-push-review.sh` reads the intercepted command from stdin JSON
2. Skips if not a push/PR command, or if pushing to `main`/`master`
3. Collects `git diff --stat` and changed file list vs `master`
4. Outputs `hookSpecificOutput.additionalContext` instructing Claude to run the review automatically
5. Claude presents findings and asks: *"Found N issue(s) — want me to fix them before pushing?"*

## Files changed
- `.claude/hooks/pre-push-review.sh` — shared hook script (committed, team-shareable)
- `.claude/settings.json` — wires `PreToolUse/Bash` → script with 300s timeout

## Notes
- Review invocation is fully automatic — no manual `/review-pr` needed
- No blocking, no marker files — simpler than a gate-based approach
- AI review logic is intentionally left as a placeholder for future implementation

## Test plan
- [ ] Run `git push` on a feature branch — verify hook fires and Claude asks about issues
- [ ] Run `git push origin master` — verify hook does NOT fire
- [ ] Run `gh pr create` — verify hook fires
- [ ] Run any other bash command — verify hook exits immediately without review

🤖 Generated with [Claude Code](https://claude.com/claude-code)