### PR TITLE
fix(plan): fix Plan page blank — response shape mismatch

### DIFF
--- a/packages/backend/src/db/queries/workout-plans.ts
+++ b/packages/backend/src/db/queries/workout-plans.ts
@@ -125,11 +125,13 @@ function mapAdjustmentRow(r: Record<string, unknown>): PlanAdjustment {
 /**
  * Returns the single current plan for a user along with its latest version,
  * or null if the user has no plan yet.
+ *
+ * Response shape matches the frontend CurrentPlanResponse: { plan, latestVersion }.
  */
 export async function getCurrentPlan(
   pool: pg.Pool,
   userId: string,
-): Promise<(WorkoutPlan & { latestVersion: PlanVersion }) | null> {
+): Promise<{ plan: WorkoutPlan; latestVersion: PlanVersion } | null> {
   // Get the most recent plan for the user
   const { rows: planRows } = await pool.query(
     `SELECT ${PLAN_COLUMNS} FROM workout_plans WHERE user_id = $1
@@ -149,7 +151,7 @@ export async function getCurrentPlan(
   if (versionRows.length === 0) return null;
 
   const latestVersion = mapVersionRow(versionRows[0] as Record<string, unknown>);
-  return { ...plan, latestVersion };
+  return { plan, latestVersion };
 }
 
 /** Returns a plan by ID, or null if not found. */

--- a/packages/backend/src/routes/__tests__/workout-plans.test.ts
+++ b/packages/backend/src/routes/__tests__/workout-plans.test.ts
@@ -178,13 +178,15 @@ describe('GET /api/workout-plans/current', () => {
   it('when user has a plan → 200 with plan + latestVersion', async () => {
     const { getCurrentPlan } = await import('../../db/queries/workout-plans.js');
     vi.mocked(getCurrentPlan).mockResolvedValueOnce({
-      id: 'plan-uuid',
-      userId: 'user-uuid',
-      name: 'My Plan',
-      splitType: 'Custom',
-      activeVersionId: 'version-uuid',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      plan: {
+        id: 'plan-uuid',
+        userId: 'user-uuid',
+        name: 'My Plan',
+        splitType: 'Custom',
+        activeVersionId: 'version-uuid',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
       latestVersion: {
         id: 'version-uuid',
         planId: 'plan-uuid',
@@ -204,7 +206,7 @@ describe('GET /api/workout-plans/current', () => {
     });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
-    expect(body.data.id).toBe('plan-uuid');
+    expect(body.data.plan.id).toBe('plan-uuid');
     expect(body.data.latestVersion).toBeDefined();
     await app.close();
   });


### PR DESCRIPTION
## Summary
Fixes the Plan page showing only a blank heading after creating a workout plan.

**Root cause:** `getCurrentPlan` returned a flat `WorkoutPlan & { latestVersion }` object, but the frontend's `CurrentPlanResponse` expected `{ plan: WorkoutPlan, latestVersion: PlanVersion }` (nested). This caused `data?.data?.plan` to always be `undefined` → page rendered neither the empty state nor the populated state.

**Fix:** Changed `getCurrentPlan` to return `{ plan, latestVersion }` (nested object) instead of `{ ...plan, latestVersion }` (spread merge). Updated the route test mock to match.

## How this happened
The backend query module was written by one subagent and the frontend types by another during the original Plan Tuner implementation (PR #60). E2E tests passed because they used mocked fixtures that had the correct nested shape — the real backend never hit the same code path during testing.

## Test plan
- [x] 411 backend tests pass (mock updated to match new shape)
- [x] 74 frontend tests pass
- [x] Manual browser verification: Plan page now renders plan data, version cards, exercise table
- [x] API returns correct `{ data: { plan: {...}, latestVersion: {...} } }` shape (verified via curl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)