### PR TITLE
fix(plan): parse D1/D2 day headers, em dashes, RIR notation

### DIFF
--- a/packages/backend/src/services/workout-plans/__tests__/plan-parser.test.ts
+++ b/packages/backend/src/services/workout-plans/__tests__/plan-parser.test.ts
@@ -90,6 +90,31 @@ Tricep Pushdown 3x12`;
     expect(pushdown!.progressionRule).toBe('double');
   });
 
+  it('"D1 — UPPER" day header format → parsed as day with exercises', () => {
+    const text = `D1 — UPPER (HEAVY | ~1 RIR)
+Iso-Lateral HS Bench — 4×5–7 @1 RIR
+Weighted Pull-Ups — 4×4–6 @1 RIR
+
+D2 — LEGS (HYPERTROPHY | 1–2 RIR)
+Leg Extension — 3×12–15 @1 RIR
+Seated Leg Curl — 3×12–15 @1 RIR`;
+
+    const result = parseFreeTextPlan(text);
+    expect(result.days).toHaveLength(2);
+    expect(result.days[0].name).toContain('UPPER');
+    expect(result.days[0].exercises.length).toBeGreaterThanOrEqual(2);
+    // Exercise name should NOT include trailing em dash
+    expect(result.days[0].exercises[0].exerciseName).not.toContain('—');
+    expect(result.days[0].exercises[0].exerciseName).toContain('Bench');
+    // RIR parsed as RPE value
+    expect(result.days[0].exercises[0].sets[0].targetRpe).toBe(1);
+    // Rep ranges parsed correctly
+    const reps = result.days[0].exercises[0].sets[0].targetReps;
+    expect(Array.isArray(reps)).toBe(true);
+    expect((reps as [number, number])[0]).toBe(5);
+    expect((reps as [number, number])[1]).toBe(7);
+  });
+
   it('exercises with RPE targets (e.g. "3×5 @RPE 8") → targetRpe is 8', () => {
     const text = `Push
 Bench Press 3x5 @RPE 8`;

--- a/packages/backend/src/services/workout-plans/plan-parser.ts
+++ b/packages/backend/src/services/workout-plans/plan-parser.ts
@@ -15,11 +15,11 @@ function inferProgressionRule(sfrTier: SfrTier): ProgressionRule {
 // ---------------------------------------------------------------------------
 
 /**
- * Matches day header lines — e.g. "Day 1:", "Monday:", "Push A:", "# Pull"
+ * Matches day header lines — e.g. "Day 1:", "Monday:", "Push A:", "# Pull", "D1 — UPPER"
  * A day header must NOT look like an exercise line (no set×rep pattern).
  */
 const DAY_HEADER_RE =
-  /^(?:#{1,3}\s*)?(?:day\s*\d+|monday|tuesday|wednesday|thursday|friday|saturday|sunday|push|pull|legs|upper|lower|full body|chest|back|arms|shoulders|core)\b/i;
+  /^(?:#{1,3}\s*)?(?:d\d+\b|day\s*\d+|monday|tuesday|wednesday|thursday|friday|saturday|sunday|push|pull|legs|upper|lower|full body|chest|back|arms|shoulders|core)\b/i;
 
 /** Matches set×rep patterns — e.g. "3x8", "3×8-12", "4×5", "3 x 10" */
 const SET_REP_RE = /(\d+)\s*[x×]\s*(\d+)(?:\s*[–-]\s*(\d+))?/i;
@@ -27,8 +27,8 @@ const SET_REP_RE = /(\d+)\s*[x×]\s*(\d+)(?:\s*[–-]\s*(\d+))?/i;
 /** Matches weight annotation — e.g. "@ 70kg", "@70 kg", "70kg", "70lbs" */
 const WEIGHT_RE = /@?\s*([\d.]+)\s*(?:kg|lbs?)/i;
 
-/** Matches RPE annotation — e.g. "@RPE 8", "RPE8", "@8", "@ 8 RPE" */
-const RPE_RE = /@\s*(?:rpe\s*)?(\d(?:\.\d)?)\s*(?:rpe)?(?!\s*k?g)/i;
+/** Matches RPE/RIR annotation — e.g. "@RPE 8", "RPE8", "@8", "@ 8 RPE", "@1 RIR", "@1–2 RIR" */
+const RPE_RE = /@\s*(?:(?:rpe|rir)\s*)?(\d(?:\.\d)?)\s*(?:rpe|rir)?(?!\s*k?g)/i;
 
 /** Matches a leading bullet or dash */
 const BULLET_RE = /^[-*•]\s*/;
@@ -79,8 +79,8 @@ function parseExerciseLine(line: string, order: number): PlanExercise | null {
 
   // Extract exercise name: everything before the set×rep pattern
   const nameRaw = stripped.substring(0, stripped.search(SET_REP_RE)).trim();
-  // Remove trailing punctuation
-  const exerciseName = nameRaw.replace(/[,.:]+$/, '').trim() || 'Exercise';
+  // Remove trailing punctuation and em dashes (common separator: "Bench Press — 3×8")
+  const exerciseName = nameRaw.replace(/[,.:\u2014\u2013-]+$/, '').trim() || 'Exercise';
 
   const meta = getExerciseMeta(exerciseName);
 

--- a/packages/frontend/src/components/plan/PlanDayCard.tsx
+++ b/packages/frontend/src/components/plan/PlanDayCard.tsx
@@ -70,7 +70,7 @@ export function PlanDayCard({ day, dayIndex: _dayIndex }: PlanDayCardProps) {
                   <td className="py-1.5 pr-4 text-muted-foreground hidden sm:table-cell">
                     {exercise.sets.find((s) => s.targetRpe !== undefined)?.targetRpe ?? '—'}
                   </td>
-                  <td className="py-1.5 text-muted-foreground hidden md:table-cell">
+                  <td className="py-1.5 text-muted-foreground hidden md:table-cell whitespace-pre-wrap max-w-md">
                     {exercise.notes ?? '—'}
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
Fixes the plan parser failing to recognize workout plans using the common coaching format:
```
D1 — UPPER (HEAVY | ~1 RIR)
Iso-Lateral HS Bench — 4×5–7 @1 RIR
```

Three parser gaps fixed:
- **Day headers:** `D1`, `D2`, etc. now recognized (added `d\d+` to `DAY_HEADER_RE`)
- **Exercise names:** trailing em dashes (`—`, `–`) stripped from names like "Bench Press —"
- **RIR notation:** `@1 RIR` now parsed as RPE value (previously only `@RPE N` was recognized)

Also fixes notes display: `whitespace-pre-wrap` on the notes table cell so fallback plans render with line breaks instead of a wall of text.

## Before / After

**Before:** entire plan dumped as a single "See notes" row — one long unformatted line
**After:** 3 structured day cards with individual exercises, sets × reps, and RIR values

## Test plan
- [x] 412 backend tests pass (+1 new parser test for D1/D2 format)
- [x] 74 frontend tests pass
- [x] Build clean (shared/backend/frontend)
- [x] Manual browser verification: pasted D1–D3 plan → 3 day cards with correct exercises

🤖 Generated with [Claude Code](https://claude.com/claude-code)